### PR TITLE
feat(M4): CLI + Public API + Quality Hardening

### DIFF
--- a/canvas/__init__.py
+++ b/canvas/__init__.py
@@ -1,1 +1,39 @@
 """Canvas — ephemeral org-aware Claude Code workspace manager."""
+
+from canvas.config import CanvasPaths, resolve_paths
+from canvas.core import (
+    archive_session,
+    list_sessions,
+    new_session,
+    nuke_session,
+    reactivate_session,
+    rename_session,
+    stale_sessions,
+)
+from canvas.exceptions import (
+    CanvasConfigError,
+    CanvasError,
+    CanvasRegistryError,
+    CanvasSessionError,
+    CanvasTemplateError,
+)
+from canvas.models import Session, SessionStatus
+
+__all__ = [
+    "CanvasConfigError",
+    "CanvasError",
+    "CanvasPaths",
+    "CanvasRegistryError",
+    "CanvasSessionError",
+    "CanvasTemplateError",
+    "Session",
+    "SessionStatus",
+    "archive_session",
+    "list_sessions",
+    "new_session",
+    "nuke_session",
+    "reactivate_session",
+    "rename_session",
+    "resolve_paths",
+    "stale_sessions",
+]

--- a/canvas/cli.py
+++ b/canvas/cli.py
@@ -1,6 +1,15 @@
 """Click CLI for canvas — commands: new, list, archive, nuke, rename, open."""
 
+import os
+
 import click
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from canvas import core
+from canvas.config import resolve_paths
+from canvas.exceptions import CanvasError, CanvasSessionError
 
 
 @click.group()
@@ -10,29 +19,84 @@ def cli() -> None:
 
 @cli.command()
 @click.argument("label", required=False)
-def new(label: str | None) -> None:
+@click.option("--org", default=None, help="Organization (overrides config).")
+def new(label: str | None, org: str | None) -> None:
     """Create a new canvas session."""
-    raise NotImplementedError
+    try:
+        session = core.new_session(label=label, org=org)
+        console = Console(stderr=True)
+        console.print(Panel(
+            f"[bold]{session.slug}[/bold]\n"
+            f"org: {session.org}  created: {session.created}",
+            title="Canvas Session Created",
+        ))
+        session_dir = str(resolve_paths().sessions_dir / session.slug)
+        os.chdir(session_dir)
+        os.execvp("claude", ["claude"])
+    except CanvasError as e:
+        raise click.ClickException(str(e))
 
 
 @cli.command("list")
-def list_sessions() -> None:
-    """List active canvas sessions."""
-    raise NotImplementedError
+@click.option("--status", type=click.Choice(["active", "archived"]), default=None)
+@click.option("--org", default=None)
+@click.option("--all", "show_all", is_flag=True, help="Show all sessions (active + archived).")
+def list_sessions(status: str | None, org: str | None, show_all: bool) -> None:
+    """List canvas sessions."""
+    try:
+        if status is not None and show_all:
+            raise click.UsageError("--status and --all are mutually exclusive.")
+        if not show_all and status is None:
+            status = "active"
+        sessions = core.list_sessions(status=status, org=org)
+        console = Console(stderr=True)
+        if not sessions:
+            console.print("[dim]No sessions found.[/dim]")
+            return
+        table = Table(title="Canvas Sessions")
+        table.add_column("Slug", style="bold")
+        table.add_column("Org")
+        table.add_column("Created")
+        table.add_column("Label")
+        table.add_column("Status")
+        for s in sessions:
+            table.add_row(
+                s.slug,
+                s.org,
+                str(s.created),
+                s.label or "",
+                str(s.status),
+            )
+        console.print(table)
+    except CanvasError as e:
+        raise click.ClickException(str(e))
 
 
 @cli.command()
 @click.argument("slug")
 def archive(slug: str) -> None:
     """Archive a canvas session."""
-    raise NotImplementedError
+    try:
+        session = core.archive_session(slug)
+        console = Console(stderr=True)
+        console.print(f"Archived [bold]{session.slug}[/bold].")
+    except CanvasError as e:
+        raise click.ClickException(str(e))
 
 
 @cli.command()
 @click.argument("slug")
-def nuke(slug: str) -> None:
+@click.option("--yes", is_flag=True, help="Skip confirmation prompt.")
+def nuke(slug: str, yes: bool) -> None:
     """Permanently destroy a canvas session."""
-    raise NotImplementedError
+    try:
+        if not yes:
+            click.confirm(f"Permanently destroy session '{slug}'?", abort=True)
+        core.nuke_session(slug)
+        console = Console(stderr=True)
+        console.print(f"Nuked [bold]{slug}[/bold].")
+    except CanvasError as e:
+        raise click.ClickException(str(e))
 
 
 @cli.command()
@@ -40,11 +104,27 @@ def nuke(slug: str) -> None:
 @click.argument("label")
 def rename(slug: str, label: str) -> None:
     """Rename a canvas session."""
-    raise NotImplementedError
+    try:
+        session = core.rename_session(slug, label)
+        console = Console(stderr=True)
+        console.print(f"Renamed [bold]{session.slug}[/bold] → {session.label}")
+    except CanvasError as e:
+        raise click.ClickException(str(e))
 
 
-@cli.command()
+@cli.command("open")
 @click.argument("slug")
-def open(slug: str) -> None:
+def open_session(slug: str) -> None:
     """Re-open an existing canvas session and launch claude."""
-    raise NotImplementedError
+    try:
+        from canvas.registry import find_session
+        session = find_session(slug)
+        if session is None:
+            raise CanvasSessionError(f"Session '{slug}' not found.")
+        session_dir = resolve_paths().sessions_dir / session.slug
+        if not session_dir.is_dir():
+            raise CanvasSessionError(f"Session directory missing: {session_dir}")
+        os.chdir(str(session_dir))
+        os.execvp("claude", ["claude"])
+    except CanvasError as e:
+        raise click.ClickException(str(e))

--- a/canvas/config.py
+++ b/canvas/config.py
@@ -15,10 +15,18 @@ class CanvasPaths:
     """Centralized path resolution for all canvas directories and files."""
 
     home: Path              # ~/.canvas (or CANVAS_HOME)
-    config: Path            # home / "config"
+    config: Path            # home / "config.json"
     registry: Path          # home / "registry.json"
     sessions_dir: Path      # home / "sessions"
     template_base: Path     # ~/.dotfiles-private/canvas/orgs
+
+
+@dataclasses.dataclass(frozen=True)
+class CanvasConfig:
+    """Parsed canvas configuration."""
+
+    org: str
+    raw: dict
 
 
 def resolve_paths(
@@ -46,29 +54,38 @@ def resolve_paths(
 
     return CanvasPaths(
         home=canvas_home,
-        config=canvas_home / "config",
+        config=canvas_home / "config.json",
         registry=canvas_home / "registry.json",
         sessions_dir=canvas_home / "sessions",
         template_base=template_base,
     )
 
 
-def load_config(paths: CanvasPaths | None = None) -> dict:
+def load_config(paths: CanvasPaths | None = None) -> CanvasConfig:
     """Load canvas config from disk.
 
-    Returns dict with at minimum {"org": "..."}.
+    Returns CanvasConfig with at minimum org set.
     Raises CanvasConfigError if file missing or malformed.
     """
     if paths is None:
         paths = resolve_paths()
 
+    # Backward-compat check: legacy config file without .json extension
+    legacy_config = paths.home / "config"
+    if legacy_config.is_file() and not paths.config.exists():
+        raise CanvasConfigError(
+            f"Found legacy config file at {legacy_config}. "
+            f"Please rename it to config.json: mv {legacy_config} {paths.config}"
+        )
+
     if not paths.config.exists():
         raise CanvasConfigError(
-            f"Config not found at {paths.config}. Run `canvas init` to set up."
+            f"Config not found at {paths.config}.\n"
+            f"Create it with: echo '{{\"org\": \"YOUR_ORG\"}}' > {paths.config}"
         )
 
     try:
-        data = json.loads(paths.config.read_text())
+        data = json.loads(paths.config.read_text(encoding="utf-8"))
     except json.JSONDecodeError as e:
         raise CanvasConfigError(
             f"Malformed config at {paths.config}: {e}"
@@ -79,4 +96,4 @@ def load_config(paths: CanvasPaths | None = None) -> dict:
             f"Config at {paths.config} missing required 'org' field."
         )
 
-    return data
+    return CanvasConfig(org=data["org"], raw=data)

--- a/canvas/core.py
+++ b/canvas/core.py
@@ -7,7 +7,7 @@ import shutil
 from pathlib import Path
 
 from canvas.config import CanvasPaths, load_config, resolve_paths
-from canvas.exceptions import CanvasError, CanvasSessionError
+from canvas.exceptions import CanvasError, CanvasRegistryError, CanvasSessionError
 from canvas.models import Session, SessionStatus
 from canvas.registry import (
     add_session,
@@ -17,7 +17,7 @@ from canvas.registry import (
     save_registry,
     update_session,
 )
-from canvas.slug import generate_slug
+from canvas.slug import generate_slug, validate_label
 from canvas.template import render_claude_md
 
 _MAX_RANDOM_SLUG_ATTEMPTS = 5
@@ -53,9 +53,11 @@ def new_session(
         paths = resolve_paths()
 
     # 2. Resolve org from config if not provided
+    config_raw: dict | None = None
     if org is None:
         config = load_config(paths)
-        org = config["org"]
+        org = config.org
+        config_raw = config.raw
 
     # 3. Capture today once to avoid date skew across midnight
     today = datetime.date.today()
@@ -85,7 +87,12 @@ def new_session(
     # 5. Create session directory, render CLAUDE.md, register session
     #    Wrap in try/except to clean up partial state on failure.
     session_dir = paths.sessions_dir / slug
-    session_dir.mkdir(parents=True)
+    try:
+        session_dir.mkdir(parents=True)
+    except OSError as e:
+        raise CanvasSessionError(
+            f"Failed to create session directory {session_dir}: {e}"
+        ) from e
 
     try:
         claude_md = render_claude_md(
@@ -95,8 +102,11 @@ def new_session(
             paths=paths,
             session_path=session_dir,
             date=today,
+            config=config_raw,
         )
-        (session_dir / "CLAUDE.md").write_text(claude_md)
+        if not claude_md.endswith("\n"):
+            claude_md += "\n"
+        (session_dir / "CLAUDE.md").write_text(claude_md, encoding="utf-8")
 
         session = Session(
             slug=slug,
@@ -144,7 +154,7 @@ def list_sessions(
     return sessions
 
 
-def archive_session(slug: str, paths: CanvasPaths | None = None) -> Session:
+def archive_session(slug: str, paths: CanvasPaths | None = None, date: datetime.date | None = None) -> Session:
     """Archive a session by setting status to ARCHIVED and archived_at to today.
 
     Directory is preserved. Raises CanvasSessionError if not found.
@@ -164,7 +174,7 @@ def archive_session(slug: str, paths: CanvasPaths | None = None) -> Session:
             slug,
             paths=paths,
             status=SessionStatus.ARCHIVED,
-            archived_at=datetime.date.today(),
+            archived_at=date or datetime.date.today(),
         )
     except CanvasError:
         raise
@@ -183,17 +193,20 @@ def nuke_session(slug: str, paths: CanvasPaths | None = None) -> None:
     if paths is None:
         paths = resolve_paths()
 
-    session = find_session(slug, paths=paths)
-    if session is None:
-        raise CanvasSessionError(f"Session '{slug}' not found.")
-
-    # Remove from registry first (orphaned dir is benign; orphaned registry entry is not)
-    remove_session(slug, paths=paths)
+    try:
+        remove_session(slug, paths=paths)
+    except CanvasRegistryError as e:
+        raise CanvasSessionError(f"Session '{slug}' not found.") from e
 
     # Remove directory if it exists
     session_dir = paths.sessions_dir / slug
     if session_dir.exists():
-        shutil.rmtree(session_dir)
+        try:
+            shutil.rmtree(session_dir)
+        except OSError as e:
+            raise CanvasSessionError(
+                f"Failed to remove session directory {session_dir}: {e}"
+            ) from e
 
 
 def rename_session(slug: str, label: str, paths: CanvasPaths | None = None) -> Session:
@@ -204,15 +217,66 @@ def rename_session(slug: str, label: str, paths: CanvasPaths | None = None) -> S
     if paths is None:
         paths = resolve_paths()
 
-    session = find_session(slug, paths)
-    if session is None:
-        raise CanvasSessionError(f"Session '{slug}' not found.")
+    validate_label(label)
 
     try:
         updated = update_session(slug, paths=paths, label=label)
+    except CanvasRegistryError as e:
+        raise CanvasSessionError(f"Session '{slug}' not found.") from e
+
+    return updated
+
+
+def reactivate_session(slug: str, paths: CanvasPaths | None = None) -> Session:
+    """Reactivate an archived session — set status to ACTIVE, clear archived_at.
+
+    Idempotent: if the session is already active, return it unchanged.
+    Raises CanvasSessionError if session not found.
+    """
+    if paths is None:
+        paths = resolve_paths()
+
+    session = find_session(slug, paths=paths)
+    if session is None:
+        raise CanvasSessionError(f"Session '{slug}' not found.")
+
+    if session.status == SessionStatus.ACTIVE:
+        return session
+
+    try:
+        updated = update_session(
+            slug,
+            paths=paths,
+            status=SessionStatus.ACTIVE,
+            archived_at=None,
+        )
     except CanvasError:
         raise
     except Exception as e:
-        raise CanvasSessionError(f"Failed to rename session '{slug}': {e}") from e
+        raise CanvasSessionError(f"Failed to reactivate session '{slug}': {e}") from e
 
     return updated
+
+
+def stale_sessions(
+    days: int = 30,
+    paths: CanvasPaths | None = None,
+    today: datetime.date | None = None,
+) -> list[Session]:
+    """Return active sessions older than *days* days.
+
+    Only considers sessions with status ACTIVE.
+    *today* can be injected for testing; defaults to datetime.date.today().
+    """
+    if paths is None:
+        paths = resolve_paths()
+
+    if today is None:
+        today = datetime.date.today()
+
+    cutoff = today - datetime.timedelta(days=days)
+    sessions = load_registry(paths)
+    return [
+        s for s in sessions
+        if s.status == SessionStatus.ACTIVE and s.created <= cutoff
+    ]

--- a/canvas/models.py
+++ b/canvas/models.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 import dataclasses
 import datetime
 from enum import StrEnum
-from typing import Self
+from typing import Any, Self
 
 
 class SessionStatus(StrEnum):
     ACTIVE = "active"
     ARCHIVED = "archived"
+
+
+_KNOWN_FIELDS = frozenset({"slug", "org", "created", "status", "label", "archived_at"})
 
 
 @dataclasses.dataclass(frozen=True)
@@ -21,23 +24,35 @@ class Session:
     status: SessionStatus
     label: str | None = None
     archived_at: datetime.date | None = None
+    extra: dict = dataclasses.field(default_factory=dict)
 
-    def to_dict(self) -> dict[str, str | None]:
-        return {
-            "slug": self.slug,
-            "org": self.org,
-            "created": self.created.isoformat(),
-            "label": self.label,
-            "archived_at": self.archived_at.isoformat() if self.archived_at else None,
-            "status": str(self.status),
-        }
+    def to_dict(self) -> dict[str, Any]:
+        result = dict(self.extra)
+        result.update(
+            {
+                "slug": self.slug,
+                "org": self.org,
+                "created": self.created.isoformat(),
+                "label": self.label,
+                "archived_at": self.archived_at.isoformat() if self.archived_at else None,
+                "status": str(self.status),
+            }
+        )
+        return result
 
     @classmethod
-    def from_dict(cls, data: dict[str, str | None]) -> Self:
+    def from_dict(cls, data: dict[str, Any]) -> Self:
         # Validate all required fields
         for field in ("slug", "org", "created", "status"):
             if field not in data:
                 raise ValueError(f"Missing required field '{field}'")
+
+        # Validate slug and org are strings
+        for field in ("slug", "org"):
+            if not isinstance(data[field], str):
+                raise ValueError(
+                    f"Field '{field}' must be a string, got {type(data[field]).__name__}"
+                )
 
         # Validate and parse created date
         try:
@@ -53,6 +68,9 @@ class Session:
             except (ValueError, TypeError) as e:
                 raise ValueError(f"Invalid 'archived_at' date: {e}") from e
 
+        # Collect unknown fields into extra
+        extra = {k: v for k, v in data.items() if k not in _KNOWN_FIELDS}
+
         return cls(
             slug=data["slug"],  # type: ignore[arg-type]
             org=data["org"],  # type: ignore[arg-type]
@@ -60,4 +78,5 @@ class Session:
             status=SessionStatus(data["status"]),  # type: ignore[arg-type]
             label=data.get("label"),  # type: ignore[arg-type]
             archived_at=archived_at,
+            extra=extra,
         )

--- a/canvas/registry.py
+++ b/canvas/registry.py
@@ -13,6 +13,7 @@ import dataclasses
 import datetime
 import json
 import os
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -32,7 +33,7 @@ def load_registry(paths: CanvasPaths | None = None) -> list[Session]:
         return []
 
     try:
-        data = json.loads(paths.registry.read_text())
+        data = json.loads(paths.registry.read_text(encoding="utf-8"))
         return [Session.from_dict(s) for s in data.get("sessions", [])]
     except (json.JSONDecodeError, ValueError, TypeError, AttributeError, KeyError) as e:
         raise CanvasRegistryError(
@@ -49,13 +50,19 @@ def save_registry(sessions: list[Session], paths: CanvasPaths | None = None) -> 
     paths.registry.parent.mkdir(parents=True, exist_ok=True)
 
     data = {"sessions": [s.to_dict() for s in sessions]}
-    tmp = paths.registry.with_suffix(f".tmp.{os.getpid()}")
+    fd, tmp_name = tempfile.mkstemp(
+        dir=paths.registry.parent, prefix="registry.json.tmp."
+    )
     try:
-        tmp.write_text(json.dumps(data, indent=2) + "\n")
-        tmp.replace(paths.registry)
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(json.dumps(data, indent=2) + "\n")
+        os.replace(tmp_name, paths.registry)
     except OSError as e:
         # Clean up temp file on failure
-        tmp.unlink(missing_ok=True)
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
         raise CanvasRegistryError(f"Failed to write registry: {e}") from e
 
 

--- a/canvas/slug.py
+++ b/canvas/slug.py
@@ -175,6 +175,30 @@ _NOUNS = (
 )
 
 
+_LABEL_MAX_LENGTH = 60
+
+
+def _to_kebab(label: str) -> str:
+    """Convert a label to kebab-case, stripping non-alphanumeric characters."""
+    kebab = label.lower().strip()
+    kebab = re.sub(r"\s+", "-", kebab)
+    kebab = re.sub(r"[^a-z0-9-]", "-", kebab)
+    kebab = re.sub(r"-+", "-", kebab)
+    return kebab.strip("-")
+
+
+def validate_label(label: str) -> None:
+    """Validate that a label contains at least one alphanumeric character.
+
+    Raises :class:`~canvas.exceptions.CanvasSessionError` if the label is
+    empty, whitespace-only, or all punctuation.
+    """
+    if not _to_kebab(label):
+        raise CanvasSessionError(
+            "Label must contain at least one alphanumeric character"
+        )
+
+
 def generate_slug(label: str | None = None, date: datetime.date | None = None) -> str:
     """Generate a dated slug for a new session.
 
@@ -182,19 +206,15 @@ def generate_slug(label: str | None = None, date: datetime.date | None = None) -
     With label: YYYY-MM-DD-kebab-cased-label
 
     If *date* is ``None``, defaults to today.
+    The kebab-cased label is truncated to 60 characters before stripping
+    trailing hyphens.
     """
     date_str = (date or datetime.date.today()).isoformat()
 
     if label is not None:
-        kebab = label.lower().strip()
-        kebab = re.sub(r"\s+", "-", kebab)
-        kebab = re.sub(r"[^a-z0-9-]", "-", kebab)
-        kebab = re.sub(r"-+", "-", kebab)
-        kebab = kebab.strip("-")
-        if not kebab:
-            raise CanvasSessionError(
-                "Label must contain at least one alphanumeric character"
-            )
+        validate_label(label)
+        kebab = _to_kebab(label)
+        kebab = kebab[:_LABEL_MAX_LENGTH].strip("-")
         return f"{date_str}-{kebab}"
 
     adj = random.choice(_ADJECTIVES)

--- a/canvas/template.py
+++ b/canvas/template.py
@@ -22,6 +22,7 @@ def render_claude_md(
     paths: CanvasPaths | None = None,
     session_path: Path | None = None,
     date: datetime.date | None = None,
+    config: dict | None = None,
 ) -> str:
     """Render a CLAUDE.md file from the org's Jinja2 template.
 
@@ -33,6 +34,7 @@ def render_claude_md(
         {{ slug }}         - session slug
         {{ label }}        - session label (empty string if None)
         {{ session_path }} - absolute path to session directory (if provided)
+        {{ config }}       - raw config dict (empty dict if not provided)
 
     If *date* is ``None``, defaults to today.
 
@@ -46,12 +48,16 @@ def render_claude_md(
 
     if not template_path.exists():
         raise CanvasTemplateError(
-            f"No template found for org '{org}' at {template_path}"
+            f"No template found for org '{org}' at {template_path}.\n"
+            f"Create it with: mkdir -p {template_path.parent} && touch {template_path}"
         )
 
     try:
-        template_text = template_path.read_text()
-        template = jinja2.Template(template_text, undefined=jinja2.StrictUndefined)
+        env = jinja2.Environment(
+            loader=jinja2.FileSystemLoader(str(template_path.parent), encoding="utf-8"),
+            undefined=jinja2.StrictUndefined,
+        )
+        template = env.get_template(template_path.name)
     except jinja2.TemplateSyntaxError as e:
         raise CanvasTemplateError(
             f"Syntax error in template for org '{org}': {e}"
@@ -64,8 +70,13 @@ def render_claude_md(
             slug=slug,
             label=label or "",
             session_path=str(session_path) if session_path else "",
+            config=config or {},
         )
     except jinja2.UndefinedError as e:
         raise CanvasTemplateError(
             f"Undefined variable in template for org '{org}': {e}"
+        ) from e
+    except jinja2.TemplateError as e:
+        raise CanvasTemplateError(
+            f"Template error for org '{org}': {e}"
         ) from e

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,10 @@
+import dataclasses
+import json
+
 import pytest
 from pathlib import Path
+
+from canvas.config import CanvasPaths, resolve_paths
 
 
 @pytest.fixture
@@ -12,3 +17,24 @@ def canvas_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setenv("CANVAS_HOME", str(home))
     monkeypatch.delenv("CANVAS_TEMPLATE_BASE", raising=False)
     return home
+
+
+def setup_config(canvas_home: Path, org: str = "acme") -> None:
+    """Write a valid config file."""
+    (canvas_home / "config.json").write_text(json.dumps({"org": org}), encoding="utf-8")
+
+
+def setup_template(template_base: Path, org: str = "acme") -> None:
+    """Write a minimal CLAUDE.md template."""
+    org_dir = template_base / org
+    org_dir.mkdir(parents=True, exist_ok=True)
+    (org_dir / "CLAUDE.md.tmpl").write_text(
+        "# {{ org }} / {{ slug }}\nLabel: {{ label }}\nDate: {{ date }}",
+        encoding="utf-8",
+    )
+
+
+def make_paths(canvas_home: Path, template_base: Path) -> CanvasPaths:
+    """Create CanvasPaths with a custom template_base for testing."""
+    base = resolve_paths(canvas_home)
+    return dataclasses.replace(base, template_base=template_base)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,287 @@
+"""Tests for canvas CLI commands."""
+
+from __future__ import annotations
+
+import datetime
+from unittest.mock import MagicMock, patch
+
+import click.testing
+import pytest
+
+from canvas.cli import cli
+from canvas.exceptions import CanvasSessionError
+from canvas.models import Session, SessionStatus
+
+
+def _make_session(
+    slug: str = "2026-03-18-test",
+    org: str = "acme",
+    label: str | None = None,
+    status: SessionStatus = SessionStatus.ACTIVE,
+) -> Session:
+    return Session(
+        slug=slug,
+        org=org,
+        created=datetime.date(2026, 3, 18),
+        status=status,
+        label=label,
+    )
+
+
+@pytest.fixture
+def runner() -> click.testing.CliRunner:
+    return click.testing.CliRunner()
+
+
+# ── canvas new ──────────────────────────────────────────────────────
+
+
+class TestNew:
+    def test_happy_path(self, runner: click.testing.CliRunner, tmp_path):
+        session = _make_session()
+        session_dir = tmp_path / "sessions" / session.slug
+        session_dir.mkdir(parents=True)
+
+        with (
+            patch("canvas.cli.core.new_session", return_value=session) as mock_new,
+            patch("canvas.cli.resolve_paths") as mock_paths,
+            patch("canvas.cli.os.chdir") as mock_chdir,
+            patch("canvas.cli.os.execvp") as mock_execvp,
+        ):
+            mock_paths.return_value = MagicMock(sessions_dir=tmp_path / "sessions")
+            result = runner.invoke(cli, ["new"])
+
+        assert result.exit_code == 0
+        mock_new.assert_called_once_with(label=None, org=None)
+        mock_chdir.assert_called_once_with(str(session_dir))
+        mock_execvp.assert_called_once_with("claude", ["claude"])
+        assert "Canvas Session Created" in result.stderr
+
+    def test_label_passed_through(self, runner: click.testing.CliRunner, tmp_path):
+        session = _make_session(label="my label")
+        session_dir = tmp_path / "sessions" / session.slug
+        session_dir.mkdir(parents=True)
+
+        with (
+            patch("canvas.cli.core.new_session", return_value=session) as mock_new,
+            patch("canvas.cli.resolve_paths") as mock_paths,
+            patch("canvas.cli.os.chdir"),
+            patch("canvas.cli.os.execvp"),
+        ):
+            mock_paths.return_value = MagicMock(sessions_dir=tmp_path / "sessions")
+            result = runner.invoke(cli, ["new", "my label"])
+
+        assert result.exit_code == 0
+        mock_new.assert_called_once_with(label="my label", org=None)
+
+    def test_org_passed_through(self, runner: click.testing.CliRunner, tmp_path):
+        session = _make_session()
+        session_dir = tmp_path / "sessions" / session.slug
+        session_dir.mkdir(parents=True)
+
+        with (
+            patch("canvas.cli.core.new_session", return_value=session) as mock_new,
+            patch("canvas.cli.resolve_paths") as mock_paths,
+            patch("canvas.cli.os.chdir"),
+            patch("canvas.cli.os.execvp"),
+        ):
+            mock_paths.return_value = MagicMock(sessions_dir=tmp_path / "sessions")
+            result = runner.invoke(cli, ["new", "--org", "myorg"])
+
+        assert result.exit_code == 0
+        mock_new.assert_called_once_with(label=None, org="myorg")
+
+    def test_canvas_error_exits_1(self, runner: click.testing.CliRunner):
+        with patch(
+            "canvas.cli.core.new_session",
+            side_effect=CanvasSessionError("boom"),
+        ):
+            result = runner.invoke(cli, ["new"])
+
+        assert result.exit_code == 1
+        assert "boom" in result.stderr
+
+
+# ── canvas list ─────────────────────────────────────────────────────
+
+
+class TestList:
+    def test_happy_path_with_sessions(self, runner: click.testing.CliRunner):
+        sessions = [
+            _make_session(slug="2026-03-18-alpha", org="acme", label="alpha"),
+            _make_session(slug="2026-03-18-beta", org="acme"),
+        ]
+
+        with patch("canvas.cli.core.list_sessions", return_value=sessions) as mock_list:
+            result = runner.invoke(cli, ["list"])
+
+        assert result.exit_code == 0
+        mock_list.assert_called_once_with(status="active", org=None)
+        assert "Canvas Sessions" in result.stderr
+        assert "2026-03-18-alpha" in result.stderr
+        assert "2026-03-18-beta" in result.stderr
+
+    def test_empty_list(self, runner: click.testing.CliRunner):
+        with patch("canvas.cli.core.list_sessions", return_value=[]):
+            result = runner.invoke(cli, ["list"])
+
+        assert result.exit_code == 0
+        assert "No sessions found" in result.stderr
+
+    def test_status_archived_filter(self, runner: click.testing.CliRunner):
+        with patch("canvas.cli.core.list_sessions", return_value=[]) as mock_list:
+            result = runner.invoke(cli, ["list", "--status", "archived"])
+
+        assert result.exit_code == 0
+        mock_list.assert_called_once_with(status="archived", org=None)
+
+    def test_show_all_no_default_status(self, runner: click.testing.CliRunner):
+        with patch("canvas.cli.core.list_sessions", return_value=[]) as mock_list:
+            result = runner.invoke(cli, ["list", "--all"])
+
+        assert result.exit_code == 0
+        mock_list.assert_called_once_with(status=None, org=None)
+
+    def test_status_and_all_mutually_exclusive(self, runner: click.testing.CliRunner):
+        result = runner.invoke(cli, ["list", "--status", "active", "--all"])
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.stderr.lower()
+
+    def test_org_filter(self, runner: click.testing.CliRunner):
+        with patch("canvas.cli.core.list_sessions", return_value=[]) as mock_list:
+            result = runner.invoke(cli, ["list", "--org", "acme"])
+
+        assert result.exit_code == 0
+        mock_list.assert_called_once_with(status="active", org="acme")
+
+
+# ── canvas archive ──────────────────────────────────────────────────
+
+
+class TestArchive:
+    def test_happy_path(self, runner: click.testing.CliRunner):
+        session = _make_session(status=SessionStatus.ARCHIVED)
+
+        with patch("canvas.cli.core.archive_session", return_value=session) as mock_archive:
+            result = runner.invoke(cli, ["archive", "2026-03-18-test"])
+
+        assert result.exit_code == 0
+        mock_archive.assert_called_once_with("2026-03-18-test")
+        assert "Archived" in result.stderr
+        assert "2026-03-18-test" in result.stderr
+
+    def test_not_found_error(self, runner: click.testing.CliRunner):
+        with patch(
+            "canvas.cli.core.archive_session",
+            side_effect=CanvasSessionError("Session 'nope' not found."),
+        ):
+            result = runner.invoke(cli, ["archive", "nope"])
+
+        assert result.exit_code == 1
+        assert "not found" in result.stderr
+
+
+# ── canvas nuke ─────────────────────────────────────────────────────
+
+
+class TestNuke:
+    def test_happy_path_with_yes(self, runner: click.testing.CliRunner):
+        with patch("canvas.cli.core.nuke_session") as mock_nuke:
+            result = runner.invoke(cli, ["nuke", "2026-03-18-test", "--yes"])
+
+        assert result.exit_code == 0
+        mock_nuke.assert_called_once_with("2026-03-18-test")
+        assert "Nuked" in result.stderr
+
+    def test_confirmation_prompt(self, runner: click.testing.CliRunner):
+        with patch("canvas.cli.core.nuke_session") as mock_nuke:
+            result = runner.invoke(cli, ["nuke", "2026-03-18-test"], input="y\n")
+
+        assert result.exit_code == 0
+        mock_nuke.assert_called_once_with("2026-03-18-test")
+
+    def test_confirmation_declined(self, runner: click.testing.CliRunner):
+        with patch("canvas.cli.core.nuke_session") as mock_nuke:
+            result = runner.invoke(cli, ["nuke", "2026-03-18-test"], input="n\n")
+
+        assert result.exit_code == 1
+        mock_nuke.assert_not_called()
+
+    def test_error_exits_1(self, runner: click.testing.CliRunner):
+        with patch(
+            "canvas.cli.core.nuke_session",
+            side_effect=CanvasSessionError("Session 'nope' not found."),
+        ):
+            result = runner.invoke(cli, ["nuke", "nope", "--yes"])
+
+        assert result.exit_code == 1
+        assert "not found" in result.stderr
+
+
+# ── canvas rename ───────────────────────────────────────────────────
+
+
+class TestRename:
+    def test_happy_path(self, runner: click.testing.CliRunner):
+        session = _make_session(label="new label")
+
+        with patch("canvas.cli.core.rename_session", return_value=session) as mock_rename:
+            result = runner.invoke(cli, ["rename", "2026-03-18-test", "new label"])
+
+        assert result.exit_code == 0
+        mock_rename.assert_called_once_with("2026-03-18-test", "new label")
+        assert "Renamed" in result.stderr
+        assert "new label" in result.stderr
+
+    def test_error_exits_1(self, runner: click.testing.CliRunner):
+        with patch(
+            "canvas.cli.core.rename_session",
+            side_effect=CanvasSessionError("Session 'nope' not found."),
+        ):
+            result = runner.invoke(cli, ["rename", "nope", "whatever"])
+
+        assert result.exit_code == 1
+        assert "not found" in result.stderr
+
+
+# ── canvas open ─────────────────────────────────────────────────────
+
+
+class TestOpen:
+    def test_happy_path(self, runner: click.testing.CliRunner, tmp_path):
+        session = _make_session()
+        session_dir = tmp_path / "sessions" / session.slug
+        session_dir.mkdir(parents=True)
+
+        with (
+            patch("canvas.registry.find_session", return_value=session),
+            patch("canvas.cli.resolve_paths") as mock_paths,
+            patch("canvas.cli.os.chdir") as mock_chdir,
+            patch("canvas.cli.os.execvp") as mock_execvp,
+        ):
+            mock_paths.return_value = MagicMock(sessions_dir=tmp_path / "sessions")
+            result = runner.invoke(cli, ["open", "2026-03-18-test"])
+
+        assert result.exit_code == 0
+        mock_chdir.assert_called_once_with(str(session_dir))
+        mock_execvp.assert_called_once_with("claude", ["claude"])
+
+    def test_not_found_exits_1(self, runner: click.testing.CliRunner):
+        with patch("canvas.registry.find_session", return_value=None):
+            result = runner.invoke(cli, ["open", "nope"])
+
+        assert result.exit_code == 1
+        assert "not found" in result.stderr
+
+    def test_directory_missing_exits_1(self, runner: click.testing.CliRunner, tmp_path):
+        session = _make_session()
+
+        with (
+            patch("canvas.registry.find_session", return_value=session),
+            patch("canvas.cli.resolve_paths") as mock_paths,
+        ):
+            mock_paths.return_value = MagicMock(sessions_dir=tmp_path / "sessions")
+            result = runner.invoke(cli, ["open", "2026-03-18-test"])
+
+        assert result.exit_code == 1
+        assert "directory missing" in result.stderr.lower()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from canvas.config import CanvasPaths, load_config, resolve_paths
+from canvas.config import CanvasConfig, CanvasPaths, load_config, resolve_paths
 from canvas.exceptions import CanvasConfigError
 
 
@@ -19,7 +19,7 @@ class TestResolvePaths:
         custom = tmp_path / "custom"
         paths = resolve_paths(canvas_home=custom)
         assert paths.home == custom
-        assert paths.config == custom / "config"
+        assert paths.config == custom / "config.json"
         assert paths.registry == custom / "registry.json"
         assert paths.sessions_dir == custom / "sessions"
 
@@ -27,7 +27,7 @@ class TestResolvePaths:
         """CANVAS_HOME env var is used when no explicit param given."""
         paths = resolve_paths()
         assert paths.home == canvas_home
-        assert paths.config == canvas_home / "config"
+        assert paths.config == canvas_home / "config.json"
         assert paths.registry == canvas_home / "registry.json"
         assert paths.sessions_dir == canvas_home / "sessions"
 
@@ -56,29 +56,37 @@ class TestLoadConfig:
     """Tests for load_config()."""
 
     def test_happy_path(self, canvas_home: Path) -> None:
-        """Valid config file is read and returned as dict."""
+        """Valid config file is read and returned as CanvasConfig."""
         config_data = {"org": "acme", "extra": "value"}
-        (canvas_home / "config").write_text(json.dumps(config_data))
+        (canvas_home / "config.json").write_text(json.dumps(config_data), encoding="utf-8")
         paths = resolve_paths()
         result = load_config(paths)
-        assert result == config_data
+        assert isinstance(result, CanvasConfig)
+        assert result.org == "acme"
+        assert result.raw == config_data
 
     def test_missing_file_raises(self, canvas_home: Path) -> None:
-        """Missing config file raises CanvasConfigError."""
+        """Missing config file raises CanvasConfigError with actionable message."""
         paths = resolve_paths()
         with pytest.raises(CanvasConfigError, match="Config not found"):
             load_config(paths)
 
+    def test_missing_file_actionable_message(self, canvas_home: Path) -> None:
+        """Missing config error includes creation command."""
+        paths = resolve_paths()
+        with pytest.raises(CanvasConfigError, match="Create it with"):
+            load_config(paths)
+
     def test_malformed_json_raises(self, canvas_home: Path) -> None:
         """Malformed JSON raises CanvasConfigError."""
-        (canvas_home / "config").write_text("{not valid json")
+        (canvas_home / "config.json").write_text("{not valid json", encoding="utf-8")
         paths = resolve_paths()
         with pytest.raises(CanvasConfigError, match="Malformed config"):
             load_config(paths)
 
     def test_missing_org_field_raises(self, canvas_home: Path) -> None:
         """Config without 'org' field raises CanvasConfigError."""
-        (canvas_home / "config").write_text(json.dumps({"name": "test"}))
+        (canvas_home / "config.json").write_text(json.dumps({"name": "test"}), encoding="utf-8")
         paths = resolve_paths()
         with pytest.raises(CanvasConfigError, match="missing required 'org' field"):
             load_config(paths)
@@ -89,10 +97,26 @@ class TestLoadConfig:
         home = tmp_path / "explicit"
         home.mkdir()
         config_data = {"org": "explicit-org"}
-        (home / "config").write_text(json.dumps(config_data))
+        (home / "config.json").write_text(json.dumps(config_data), encoding="utf-8")
         paths = resolve_paths(canvas_home=home)
         result = load_config(paths)
-        assert result == config_data
+        assert result.org == "explicit-org"
+        assert result.raw == config_data
+
+    def test_legacy_config_raises(self, canvas_home: Path) -> None:
+        """Legacy config file (without .json) raises with migration message."""
+        (canvas_home / "config").write_text(json.dumps({"org": "acme"}), encoding="utf-8")
+        paths = resolve_paths()
+        with pytest.raises(CanvasConfigError, match="legacy config file"):
+            load_config(paths)
+
+    def test_legacy_config_not_triggered_when_json_exists(self, canvas_home: Path) -> None:
+        """Legacy check is skipped when config.json already exists."""
+        (canvas_home / "config").write_text(json.dumps({"org": "old"}), encoding="utf-8")
+        (canvas_home / "config.json").write_text(json.dumps({"org": "new"}), encoding="utf-8")
+        paths = resolve_paths()
+        result = load_config(paths)
+        assert result.org == "new"
 
 
 class TestResolvePathsTemplateBase:
@@ -130,3 +154,13 @@ class TestCanvasPathsFrozen:
         paths = resolve_paths(canvas_home=Path("/tmp/test"))
         with pytest.raises(dataclasses.FrozenInstanceError):
             paths.home = Path("/tmp/other")  # type: ignore[misc]
+
+
+class TestCanvasConfigFrozen:
+    """Tests for CanvasConfig immutability."""
+
+    def test_frozen(self) -> None:
+        """CanvasConfig instances are immutable."""
+        cfg = CanvasConfig(org="acme", raw={"org": "acme"})
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            cfg.org = "other"  # type: ignore[misc]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -20,7 +20,7 @@ from canvas.slug import generate_slug
 
 def _setup_config(canvas_home: Path, org: str = "acme") -> None:
     """Write a valid config file."""
-    (canvas_home / "config").write_text(json.dumps({"org": org}))
+    (canvas_home / "config.json").write_text(json.dumps({"org": org}), encoding="utf-8")
 
 
 def _setup_template(template_base: Path, org: str = "acme") -> None:

--- a/tests/test_core_api.py
+++ b/tests/test_core_api.py
@@ -1,0 +1,233 @@
+"""Tests for reactivate_session, stale_sessions, and public API imports."""
+
+from __future__ import annotations
+
+import datetime
+from pathlib import Path
+
+import pytest
+
+from canvas.config import resolve_paths
+from canvas.core import reactivate_session, stale_sessions
+from canvas.exceptions import CanvasSessionError
+from canvas.models import Session, SessionStatus
+from canvas.registry import add_session, load_registry
+
+
+@pytest.fixture
+def paths(canvas_home: Path):
+    """Resolve CanvasPaths using the test canvas_home."""
+    return resolve_paths(canvas_home=canvas_home)
+
+
+@pytest.fixture
+def populated_registry(paths):
+    """Pre-populate registry with a mix of sessions for testing."""
+    sessions = [
+        Session(
+            slug="active-recent",
+            org="acme",
+            created=datetime.date(2026, 3, 1),
+            status=SessionStatus.ACTIVE,
+            label="Recent Active",
+        ),
+        Session(
+            slug="active-old",
+            org="acme",
+            created=datetime.date(2026, 1, 1),
+            status=SessionStatus.ACTIVE,
+            label="Old Active",
+        ),
+        Session(
+            slug="archived-old",
+            org="acme",
+            created=datetime.date(2025, 12, 1),
+            status=SessionStatus.ARCHIVED,
+            label="Old Archived",
+            archived_at=datetime.date(2026, 1, 15),
+        ),
+        Session(
+            slug="archived-recent",
+            org="globex",
+            created=datetime.date(2026, 2, 20),
+            status=SessionStatus.ARCHIVED,
+            label="Recent Archived",
+            archived_at=datetime.date(2026, 3, 1),
+        ),
+    ]
+    for s in sessions:
+        add_session(s, paths)
+    return sessions
+
+
+# ── reactivate_session ──
+
+
+class TestReactivateSession:
+    def test_happy_path(self, paths, populated_registry):
+        """Archived session becomes active, archived_at cleared."""
+        result = reactivate_session("archived-old", paths=paths)
+        assert result.status == SessionStatus.ACTIVE
+        assert result.archived_at is None
+        assert result.slug == "archived-old"
+        # Verify persisted
+        sessions = load_registry(paths)
+        found = next(s for s in sessions if s.slug == "archived-old")
+        assert found.status == SessionStatus.ACTIVE
+        assert found.archived_at is None
+
+    def test_not_found(self, paths, populated_registry):
+        """Raises CanvasSessionError if session not found."""
+        with pytest.raises(CanvasSessionError, match="not found"):
+            reactivate_session("nonexistent", paths=paths)
+
+    def test_already_active_is_idempotent(self, paths, populated_registry):
+        """Already active session returned unchanged."""
+        result = reactivate_session("active-recent", paths=paths)
+        assert result.status == SessionStatus.ACTIVE
+        assert result.slug == "active-recent"
+        assert result.label == "Recent Active"
+
+    def test_reactivate_recently_archived(self, paths, populated_registry):
+        """Recently archived session can be reactivated."""
+        result = reactivate_session("archived-recent", paths=paths)
+        assert result.status == SessionStatus.ACTIVE
+        assert result.archived_at is None
+        assert result.org == "globex"
+
+    def test_not_found_empty_registry(self, paths):
+        """Raises CanvasSessionError on empty registry."""
+        with pytest.raises(CanvasSessionError, match="not found"):
+            reactivate_session("anything", paths=paths)
+
+
+# ── stale_sessions ──
+
+
+class TestStaleSessions:
+    def test_sessions_older_than_30_days(self, paths, populated_registry):
+        """Sessions older than 30 days returned with default days."""
+        today = datetime.date(2026, 3, 15)
+        result = stale_sessions(paths=paths, today=today)
+        slugs = [s.slug for s in result]
+        assert "active-old" in slugs  # created 2026-01-01, 73 days old
+        assert "active-recent" not in slugs  # created 2026-03-01, 14 days old
+
+    def test_recent_sessions_not_returned(self, paths, populated_registry):
+        """Recent sessions should not appear as stale."""
+        today = datetime.date(2026, 3, 15)
+        result = stale_sessions(paths=paths, today=today)
+        slugs = [s.slug for s in result]
+        assert "active-recent" not in slugs
+
+    def test_empty_registry(self, paths):
+        """Empty registry returns empty list."""
+        result = stale_sessions(paths=paths, today=datetime.date(2026, 3, 15))
+        assert result == []
+
+    def test_custom_today_parameter(self, paths, populated_registry):
+        """Custom today parameter shifts the cutoff."""
+        # With today far in the future, all active sessions are stale
+        far_future = datetime.date(2027, 6, 1)
+        result = stale_sessions(paths=paths, today=far_future)
+        slugs = [s.slug for s in result]
+        assert "active-old" in slugs
+        assert "active-recent" in slugs
+
+    def test_only_active_sessions_considered(self, paths, populated_registry):
+        """Archived sessions ignored even if old."""
+        today = datetime.date(2026, 3, 15)
+        result = stale_sessions(paths=paths, today=today)
+        slugs = [s.slug for s in result]
+        # archived-old is old but archived — should not appear
+        assert "archived-old" not in slugs
+        assert "archived-recent" not in slugs
+
+    def test_custom_days_parameter(self, paths, populated_registry):
+        """Custom days parameter adjusts the threshold."""
+        today = datetime.date(2026, 3, 15)
+        # With days=10, active-recent (created 2026-03-01, 14 days ago) is stale
+        result = stale_sessions(days=10, paths=paths, today=today)
+        slugs = [s.slug for s in result]
+        assert "active-recent" in slugs
+        assert "active-old" in slugs
+
+    def test_boundary_exactly_n_days(self, paths, populated_registry):
+        """Session created exactly N days ago IS stale (created <= cutoff)."""
+        # active-old created 2026-01-01; set today so cutoff == 2026-01-01
+        # cutoff = 2026-01-31 - 30 days = 2026-01-01
+        today = datetime.date(2026, 1, 31)
+        result = stale_sessions(days=30, paths=paths, today=today)
+        slugs = [s.slug for s in result]
+        assert "active-old" in slugs
+
+
+# ── Public API imports ──
+
+
+class TestPublicAPIImports:
+    def test_import_new_session(self):
+        """from canvas import new_session works."""
+        from canvas import new_session
+        assert callable(new_session)
+
+    def test_import_models(self):
+        """from canvas import Session, SessionStatus works."""
+        from canvas import Session, SessionStatus
+        assert Session is not None
+        assert SessionStatus is not None
+
+    def test_all_is_complete(self):
+        """All names in __all__ are importable."""
+        import canvas
+        for name in canvas.__all__:
+            assert hasattr(canvas, name), f"canvas.{name} not importable"
+
+    def test_dir_includes_expected_names(self):
+        """dir(canvas) includes all expected names."""
+        import canvas
+        module_dir = dir(canvas)
+        expected = [
+            "CanvasConfigError",
+            "CanvasError",
+            "CanvasPaths",
+            "CanvasRegistryError",
+            "CanvasSessionError",
+            "CanvasTemplateError",
+            "Session",
+            "SessionStatus",
+            "archive_session",
+            "list_sessions",
+            "new_session",
+            "nuke_session",
+            "reactivate_session",
+            "rename_session",
+            "resolve_paths",
+            "stale_sessions",
+        ]
+        for name in expected:
+            assert name in module_dir, f"{name} not in dir(canvas)"
+
+    def test_import_reactivate_session(self):
+        """from canvas import reactivate_session works."""
+        from canvas import reactivate_session
+        assert callable(reactivate_session)
+
+    def test_import_stale_sessions(self):
+        """from canvas import stale_sessions works."""
+        from canvas import stale_sessions
+        assert callable(stale_sessions)
+
+    def test_import_exceptions(self):
+        """from canvas import exception classes works."""
+        from canvas import (
+            CanvasConfigError,
+            CanvasError,
+            CanvasRegistryError,
+            CanvasSessionError,
+            CanvasTemplateError,
+        )
+        assert issubclass(CanvasConfigError, CanvasError)
+        assert issubclass(CanvasRegistryError, CanvasError)
+        assert issubclass(CanvasSessionError, CanvasError)
+        assert issubclass(CanvasTemplateError, CanvasError)

--- a/tests/test_core_session_mgmt.py
+++ b/tests/test_core_session_mgmt.py
@@ -109,16 +109,16 @@ class TestListSessions:
 
 class TestArchiveSession:
     def test_happy_path(self, paths, populated_registry):
-        today = datetime.date.today()
-        result = archive_session("alpha", paths=paths)
+        fixed_date = datetime.date(2026, 6, 15)
+        result = archive_session("alpha", paths=paths, date=fixed_date)
         assert result.status == SessionStatus.ARCHIVED
-        assert result.archived_at == today
+        assert result.archived_at == fixed_date
         assert result.slug == "alpha"
         # Verify persisted
         sessions = load_registry(paths)
         alpha = next(s for s in sessions if s.slug == "alpha")
         assert alpha.status == SessionStatus.ARCHIVED
-        assert alpha.archived_at == today
+        assert alpha.archived_at == fixed_date
 
     def test_already_archived_is_idempotent(self, paths, populated_registry):
         result = archive_session("beta", paths=paths)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -145,18 +145,51 @@ class TestSession:
         with pytest.raises(ValueError, match="Missing required field 'org'"):
             Session.from_dict(data)
 
-    def test_from_dict_extra_unknown_fields_ignored(self):
+    def test_from_dict_extra_unknown_fields_preserved(self):
         data = {
             "slug": "s",
             "org": "o",
             "created": "2026-01-01",
             "status": "active",
             "label": None,
-            "unknown_field": "should be ignored",
+            "unknown_field": "should be preserved",
+            "another": 42,
         }
         s = Session.from_dict(data)
         assert s.slug == "s"
-        assert not hasattr(s, "unknown_field")
+        assert s.extra == {"unknown_field": "should be preserved", "another": 42}
+
+    def test_extra_fields_round_trip(self):
+        """Unknown fields survive a to_dict -> from_dict round trip."""
+        data = {
+            "slug": "s",
+            "org": "o",
+            "created": "2026-01-01",
+            "status": "active",
+            "custom_key": "custom_value",
+        }
+        s = Session.from_dict(data)
+        d = s.to_dict()
+        assert d["custom_key"] == "custom_value"
+        s2 = Session.from_dict(d)
+        assert s2.extra == {"custom_key": "custom_value"}
+        assert s2 == s
+
+    def test_known_fields_take_precedence_over_extra(self):
+        """Known fields overwrite any conflicting extra keys in to_dict."""
+        s = Session(
+            slug="s",
+            org="o",
+            created=_DATE,
+            status=SessionStatus.ACTIVE,
+            extra={"slug": "should-be-overwritten"},
+        )
+        d = s.to_dict()
+        assert d["slug"] == "s"
+
+    def test_extra_defaults_to_empty_dict(self):
+        s = Session(slug="s", org="o", created=_DATE, status=SessionStatus.ACTIVE)
+        assert s.extra == {}
 
     def test_equality(self):
         a = Session(slug="s", org="o", created=_DATE, status=SessionStatus.ACTIVE)
@@ -179,6 +212,26 @@ class TestSession:
         )
         reconstructed = Session.from_dict(original.to_dict())
         assert reconstructed == original
+
+    def test_from_dict_slug_not_string_raises(self):
+        data = {"slug": 123, "org": "o", "created": "2026-01-01", "status": "active"}
+        with pytest.raises(ValueError, match="Field 'slug' must be a string, got int"):
+            Session.from_dict(data)
+
+    def test_from_dict_slug_none_raises(self):
+        data = {"slug": None, "org": "o", "created": "2026-01-01", "status": "active"}
+        with pytest.raises(ValueError, match="Field 'slug' must be a string, got NoneType"):
+            Session.from_dict(data)
+
+    def test_from_dict_org_not_string_raises(self):
+        data = {"slug": "s", "org": 456, "created": "2026-01-01", "status": "active"}
+        with pytest.raises(ValueError, match="Field 'org' must be a string, got int"):
+            Session.from_dict(data)
+
+    def test_from_dict_org_none_raises(self):
+        data = {"slug": "s", "org": None, "created": "2026-01-01", "status": "active"}
+        with pytest.raises(ValueError, match="Field 'org' must be a string, got NoneType"):
+            Session.from_dict(data)
 
     def test_from_dict_invalid_archived_at(self):
         data = {

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -52,7 +52,7 @@ class TestLoadRegistry:
                 }
             ]
         }
-        registry_path.write_text(json.dumps(data))
+        registry_path.write_text(json.dumps(data), encoding="utf-8")
         sessions = load_registry()
         assert len(sessions) == 1
         assert sessions[0].slug == "s1"
@@ -60,20 +60,20 @@ class TestLoadRegistry:
 
     def test_corrupt_json_raises(self, canvas_home: Path):
         registry_path = canvas_home / "registry.json"
-        registry_path.write_text("{not valid json")
+        registry_path.write_text("{not valid json", encoding="utf-8")
         with pytest.raises(CanvasRegistryError, match="Corrupt registry"):
             load_registry()
 
     def test_invalid_session_data_raises(self, canvas_home: Path):
         registry_path = canvas_home / "registry.json"
         data = {"sessions": [{"slug": "s", "org": "o", "created": "bad", "status": "active"}]}
-        registry_path.write_text(json.dumps(data))
+        registry_path.write_text(json.dumps(data), encoding="utf-8")
         with pytest.raises(CanvasRegistryError, match="Corrupt registry"):
             load_registry()
 
     def test_empty_sessions_list(self, canvas_home: Path):
         registry_path = canvas_home / "registry.json"
-        registry_path.write_text(json.dumps({"sessions": []}))
+        registry_path.write_text(json.dumps({"sessions": []}), encoding="utf-8")
         sessions = load_registry()
         assert sessions == []
 
@@ -83,7 +83,7 @@ class TestSaveRegistry:
         session = _make_session()
         save_registry([session])
         registry_path = canvas_home / "registry.json"
-        data = json.loads(registry_path.read_text())
+        data = json.loads(registry_path.read_text(encoding="utf-8"))
         assert len(data["sessions"]) == 1
         assert data["sessions"][0]["slug"] == "test-session"
 
@@ -101,7 +101,7 @@ class TestSaveRegistry:
 
     def test_save_empty_list(self, canvas_home: Path):
         save_registry([])
-        data = json.loads((canvas_home / "registry.json").read_text())
+        data = json.loads((canvas_home / "registry.json").read_text(encoding="utf-8"))
         assert data == {"sessions": []}
 
     def test_creates_parent_dirs(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
@@ -227,7 +227,7 @@ class TestCRUDCycle:
 class TestSaveRegistryErrors:
     def test_oserror_on_replace_cleans_up_tmp(self, canvas_home: Path):
         """OSError during atomic replace raises CanvasRegistryError and cleans up temp file."""
-        with patch.object(Path, "replace", side_effect=OSError("permission denied")):
+        with patch("os.replace", side_effect=OSError("permission denied")):
             with pytest.raises(CanvasRegistryError, match="Failed to write registry"):
                 save_registry([_make_session()])
         # The temp file should have been cleaned up by the except branch
@@ -238,7 +238,7 @@ class TestSaveRegistryErrors:
 class TestLoadRegistryEdgeCases:
     def test_missing_sessions_key_returns_empty(self, canvas_home: Path):
         """Valid JSON without a 'sessions' key returns empty list."""
-        (canvas_home / "registry.json").write_text('{"version": 1}')
+        (canvas_home / "registry.json").write_text('{"version": 1}', encoding="utf-8")
         sessions = load_registry()
         assert sessions == []
 
@@ -252,7 +252,7 @@ class TestExplicitPaths:
                 {"slug": "s1", "org": "acme", "created": "2026-01-01", "status": "active"}
             ]
         }
-        registry_path.write_text(json.dumps(data))
+        registry_path.write_text(json.dumps(data), encoding="utf-8")
         sessions = load_registry(paths=paths)
         assert len(sessions) == 1
         assert sessions[0].slug == "s1"

--- a/tests/test_slug.py
+++ b/tests/test_slug.py
@@ -8,7 +8,7 @@ import re
 import pytest
 
 from canvas.exceptions import CanvasSessionError
-from canvas.slug import _ADJECTIVES, _NOUNS, generate_slug
+from canvas.slug import _ADJECTIVES, _NOUNS, generate_slug, validate_label
 
 FIXED_DATE = datetime.date(2025, 7, 15)
 FIXED_ISO = FIXED_DATE.isoformat()  # "2025-07-15"
@@ -110,3 +110,49 @@ class TestGenerateSlugWithLabel:
     def test_unicode_label_stripped(self) -> None:
         slug = generate_slug("café plan", date=FIXED_DATE)
         assert slug == f"{FIXED_ISO}-caf-plan"
+
+    def test_label_truncated_at_60_chars(self) -> None:
+        long_label = "a" * 100
+        slug = generate_slug(long_label, date=FIXED_DATE)
+        # The kebab part (after the date prefix) should be at most 60 chars
+        kebab_part = slug[len(FIXED_ISO) + 1 :]
+        assert len(kebab_part) <= 60
+
+    def test_label_truncation_strips_trailing_hyphen(self) -> None:
+        # Build a label that will have a hyphen at position 60
+        # "a-" repeated = positions 0:a 1:- 2:a 3:- ...
+        # At position 59 we want a hyphen so truncation at 60 leaves trailing hyphen
+        label = "a-" * 40  # 80 chars, kebab will be "a-a-a-a-..."
+        slug = generate_slug(label, date=FIXED_DATE)
+        kebab_part = slug[len(FIXED_ISO) + 1 :]
+        assert len(kebab_part) <= 60
+        assert not kebab_part.endswith("-")
+
+    def test_label_exactly_60_chars_not_truncated(self) -> None:
+        label = "a" * 60
+        slug = generate_slug(label, date=FIXED_DATE)
+        kebab_part = slug[len(FIXED_ISO) + 1 :]
+        assert kebab_part == "a" * 60
+
+
+class TestValidateLabel:
+    def test_valid_label_does_not_raise(self) -> None:
+        validate_label("hello world")  # should not raise
+
+    def test_empty_label_raises(self) -> None:
+        with pytest.raises(CanvasSessionError, match="alphanumeric"):
+            validate_label("")
+
+    def test_whitespace_only_raises(self) -> None:
+        with pytest.raises(CanvasSessionError, match="alphanumeric"):
+            validate_label("   ")
+
+    def test_all_punctuation_raises(self) -> None:
+        with pytest.raises(CanvasSessionError, match="alphanumeric"):
+            validate_label("!@#$%")
+
+    def test_single_alphanumeric_passes(self) -> None:
+        validate_label("a")  # should not raise
+
+    def test_mixed_valid_content_passes(self) -> None:
+        validate_label("hello 123!")  # should not raise

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -72,6 +72,13 @@ class TestRenderClaudeMdMissingTemplate:
         assert "missing-org" in msg
         assert str(template_base) in msg
 
+    def test_missing_template_actionable_message(self, template_env):
+        """Missing template error includes creation instructions."""
+        paths, _ = template_env
+
+        with pytest.raises(CanvasTemplateError, match="Create it with"):
+            render_claude_md(org="nonexistent", slug="s", paths=paths)
+
 
 class TestRenderClaudeMdMalformedTemplate:
     """Malformed Jinja2 templates raise CanvasTemplateError."""
@@ -183,3 +190,47 @@ class TestRenderClaudeMdMultipleOrgs:
         assert "Org: alpha" in result_alpha
         assert "Welcome to beta!" in result_beta
         assert "Org: beta" in result_beta
+
+
+class TestRenderClaudeMdConfigVariable:
+    """config dict is available as a template variable."""
+
+    def test_config_custom_key(self, template_env):
+        """Custom config keys are accessible via {{ config.custom_key }}."""
+        paths, template_base = template_env
+        org_dir = template_base / "cfgorg"
+        org_dir.mkdir()
+        (org_dir / "CLAUDE.md.tmpl").write_text("Custom: {{ config.custom_key }}")
+
+        result = render_claude_md(
+            org="cfgorg", slug="s", paths=paths,
+            config={"custom_key": "hello-world"},
+        )
+
+        assert "Custom: hello-world" in result
+
+    def test_config_none_defaults_to_empty_dict(self, template_env):
+        """When config is None, config is an empty dict in the template."""
+        paths, template_base = template_env
+        org_dir = template_base / "cfgorg2"
+        org_dir.mkdir()
+        (org_dir / "CLAUDE.md.tmpl").write_text("Has config: {{ config | length }}")
+
+        result = render_claude_md(org="cfgorg2", slug="s", paths=paths)
+
+        assert "Has config: 0" in result
+
+
+class TestRenderClaudeMdTemplateErrorFallback:
+    """Non-syntax, non-undefined TemplateErrors are caught as fallback."""
+
+    def test_generic_template_error_raises(self, template_env):
+        """A TemplateError that is not UndefinedError or SyntaxError is caught."""
+        paths, template_base = template_env
+        org_dir = template_base / "errtmpl"
+        org_dir.mkdir()
+        # Use a recursive include to trigger a TemplateError (template not found by loader)
+        (org_dir / "CLAUDE.md.tmpl").write_text("{% include 'nonexistent.html' %}")
+
+        with pytest.raises(CanvasTemplateError, match="Template error"):
+            render_claude_md(org="errtmpl", slug="s", paths=paths)


### PR DESCRIPTION
## Summary

Milestone 4 wires canvas end-to-end: implements all 6 CLI commands, exposes the public API, and resolves 23 quality/hardening issues from review deferrals.

- **CLI Commands** (#9, #10, #12): `canvas new/list/archive/nuke/rename/open` — Rich output on stderr, `--org`/`--status`/`--all`/`--yes` flags, mutually exclusive `--status`/`--all`
- **Public API** (#11, #23): `__init__.py` exports 16 symbols; `reactivate_session()` and `stale_sessions()` added to core
- **Config/Template Hardening** (#19-21, #25-29, #31-32, #35-37): config.json migration with legacy detection, `CanvasConfig` dataclass, `config.raw` in templates, actionable errors, `jinja2.Environment`+`FileSystemLoader`, `encoding="utf-8"` everywhere, eliminated double registry reads, `validate_label()` in rename, OSError wrapping, trailing newline on CLAUDE.md
- **Models/Registry/Slug Hardening** (#24, #28, #30, #33-34, #38): label truncation at 60 chars, `_to_kebab` DRY helper, `Session.extra` preserves unknown fields, thread-safe `tempfile.mkstemp`, shared conftest helpers, type validation in `Session.from_dict`

**214 tests pass** (64 new, 150 existing). 18 files changed, +1079 −93.

## Test plan

- [x] `python3 -m pytest tests/ -v` — 214 passed
- [x] `from canvas import new_session, Session, __all__` — public API imports verified
- [x] 3 parallel code reviews completed, all findings addressed
- [ ] CI passes on this PR